### PR TITLE
Improve typings for EventEmitter-related api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .vscode
+.vim

--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,5 @@
 export { EventEmitter, on } from "https://deno.land/std@0.92.0/node/events.ts";
-export { serve, Server } from "https://deno.land/std@0.92.0/http/server.ts";
+export { serve, Server, ServerRequest } from "https://deno.land/std@0.92.0/http/server.ts";
 export {
   acceptWebSocket,
   isWebSocketCloseEvent,

--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "./../deps.ts";
-import { serve, Server } from "./../deps.ts";
+import { serve, Server, ServerRequest } from "./../deps.ts";
 import {
   acceptWebSocket,
   isWebSocketCloseEvent,
@@ -17,7 +17,16 @@ export enum WebSocketState {
   CLOSED = 3,
 }
 
+export type DefaultServerEventTypes = {
+  connection: (ws: WebSocketClient, url: ServerRequest["url"]) => void;
+  error: (err: any) => void;
+};
+
 export class WebSocketServer extends EventEmitter {
+  on <K extends keyof DefaultServerEventTypes>(eventType: K, listener: DefaultServerEventTypes[K]): this;
+  on (...params: Parameters<EventEmitter["on"]>): this;
+  on (...params: Parameters<EventEmitter["on"]>): this { return super.on(...params) };
+
   clients: Set<WebSocketAcceptedClient> = new Set<WebSocketAcceptedClient>();
   server?: Server = undefined;
   constructor(

--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -83,9 +83,9 @@ export class WebSocketServer extends GenericEventEmitter<DefaultServerEventTypes
   }
 }
 
-export type DefaultClientEventTypes = {
+export type DefaultClientEventTypes<AllowedMessageEventContent> = {
   open: () => void;
-  message: (data: string | Uint8Array) => void;
+  message: (data: MessageEvent<AllowedMessageEventContent> | AllowedMessageEventContent) => void;
   ping: (data: Uint8Array) => void;
   pong: (data: Uint8Array) => void;
   close: (code?: number | WebSocketError | unknown) => void; // unknown is an "any" error in catch - maybe worth wrapping?
@@ -100,7 +100,9 @@ export interface WebSocketClient extends EventEmitter {
   isClosed: boolean | undefined;
 }
 
-export class WebSocketAcceptedClient extends GenericEventEmitter<DefaultClientEventTypes>
+type WebSocketAcceptedClientAllowedMessageEventContent = string | Uint8Array;
+type DefaultAcceptedClientEventTypes = DefaultClientEventTypes<WebSocketAcceptedClientAllowedMessageEventContent>;
+export class WebSocketAcceptedClient extends GenericEventEmitter<DefaultAcceptedClientEventTypes>
  implements WebSocketClient {
   state: WebSocketState = WebSocketState.CONNECTING;
   webSocket: DenoWebSocketType;
@@ -197,7 +199,7 @@ export class WebSocketAcceptedClient extends GenericEventEmitter<DefaultClientEv
   }
 }
 
-export class StandardWebSocketClient extends GenericEventEmitter<DefaultClientEventTypes>
+export class StandardWebSocketClient extends GenericEventEmitter<DefaultClientEventTypes<any>>
   implements WebSocketClient {
   webSocket?: WebSocket;
   constructor(private endpoint?: string) {

--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -85,7 +85,7 @@ export class WebSocketServer extends GenericEventEmitter<DefaultServerEventTypes
 
 export type DefaultClientEventTypes<AllowedMessageEventContent> = {
   open: () => void;
-  message: (data: MessageEvent<AllowedMessageEventContent> | AllowedMessageEventContent) => void;
+  message: (data: AllowedMessageEventContent) => void;
   ping: (data: Uint8Array) => void;
   pong: (data: Uint8Array) => void;
   close: (code?: number | WebSocketError | unknown) => void; // unknown is an "any" error in catch - maybe worth wrapping?

--- a/lib/websocket.ts
+++ b/lib/websocket.ts
@@ -17,13 +17,13 @@ export enum WebSocketState {
   CLOSED = 3,
 }
 
-export type EventTypesSet = { [key: string]: (...params: any[]) => void }; 
+export type EventTypesMap = { [key: string]: (...params: any[]) => void };
 export type DefaultServerEventTypes = {
   connection: (ws: WebSocketClient, url: ServerRequest["url"]) => void;
   error: (err: Error | unknown) => void; // unknown is an "any" error in catch case - maybe worth wrapping?
 };
 
-export class GenericEventEmitter<EventTypes extends EventTypesSet> extends EventEmitter {
+export class GenericEventEmitter<EventTypes extends EventTypesMap> extends EventEmitter {
   on <K extends keyof EventTypes>(eventType: K, listener: EventTypes[K]): this;
   /** @deprecated unsafe fallback to EventEmitter.on (no typeguards) */
   on (...params: Parameters<EventEmitter["on"]>): this;


### PR DESCRIPTION
Opening this PR to open discussion about this topic.
If this change is welcome - I want to do very similar types for WebSocketClient/WebSocketAcceptedClient "on".